### PR TITLE
Move sqlite3 import to package mbtiles

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/evalphobia/logrus_sentry"
 	"github.com/labstack/echo/middleware"
-	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 

--- a/mbtiles/mbtiles.go
+++ b/mbtiles/mbtiles.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
+
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
I stumbled upon this while integrating the handlers: If the anonymous import of `github.com/mattn/go-sqlite3` is not performed in `mbtiles`, any program using `mbtiles` would need to import it by itself, otherwise it panics since the DB type "sqlite3" is not supported.

To get rid of that I moved the import to the package `mbtiles` directly. That makes sense because the MBTiles format is closely coupled to SQLite3 anyway.