### PR TITLE
mbtiles: Add ServiceSet.TileMux as the minimal handler

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -187,7 +187,7 @@ func (s *ServiceSet) listServices(w http.ResponseWriter, r *http.Request) (int, 
 	return http.StatusOK, err
 }
 
-func (s *ServiceSet) serviceInfo(id string, db *mbtiles.DB) handlerFunc {
+func (s *ServiceSet) tileJSON(id string, db *mbtiles.DB) handlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) (int, error) {
 		svcURL := fmt.Sprintf("%s%s", s.RootURL(r), r.URL.Path)
 		imgFormat := db.TileFormatString()
@@ -411,7 +411,7 @@ func (s *ServiceSet) TileMux(ef func(error)) *http.ServeMux {
 	m := http.NewServeMux()
 	for id, db := range s.tilesets {
 		p := "/services/" + id
-		m.Handle(p, wrapGetWithErrors(ef, s.serviceInfo(id, db)))
+		m.Handle(p, wrapGetWithErrors(ef, s.tileJSON(id, db)))
 		m.Handle(p+"/tiles/", wrapGetWithErrors(ef, s.tiles(db)))
 	}
 	return m

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -426,12 +426,6 @@ func (s *ServiceSet) Handler(ef func(error)) http.Handler {
 	for id, db := range s.tilesets {
 		p := "/services/" + id
 		m.Handle(p+"/map", wrapGetWithErrors(ef, s.serviceHTML(id, db)))
-		// TODO arcgis handlers
-		// p = "//arcgis/rest/services/" + id + "/MapServer"
-		// m.Handle(p, wrapGetWithErrors(s.getArcGISService))
-		// m.Handle(p + "/layers", wrapGetWithErrors(s.getArcGISLayers))
-		// m.Handle(p + "/legend", wrapGetWithErrors(s.getArcGISLegend))
-		// m.Handle(p + "/tile/", wrapGetWithErrors(s.getArcGISTile))
 	}
 	return m
 }


### PR DESCRIPTION
TileMux returns an `*http.ServeMux` (which implements `http.Handler`) that will only serve the tiles and the TileJSON.

Also, refactor the `Handler` method to use `TileMux`.