### PR TITLE
Add support for HMAC-based per-service authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ small time window.
 
 ### Creating signatures
 
-A signatures is a URL-safe, base64 encoded HMAC hash using the `SHA1` algorithm. The hash key is an `SHA1` key created
+A signature is a URL-safe, base64 encoded HMAC hash using the `SHA1` algorithm. The hash key is an `SHA1` key created
 from a randomly generated salt, and the **secret key** string. The hash payload is a combination of the ISO-formatted 
 date when the hash was created, and the authorized service id.
 

--- a/handlers/arcgis.go
+++ b/handlers/arcgis.go
@@ -376,11 +376,11 @@ func (s *ServiceSet) ArcGISHandler(ef func(error)) http.Handler {
 
 	for id, db := range s.tilesets {
 		p := rootPath + id + "/MapServer"
-		m.Handle(p, wrapGetWithErrors(ef, s.arcgisService(id, db)))
-		m.Handle(p+"/layers", wrapGetWithErrors(ef, s.arcgisLayers(id, db)))
-		m.Handle(p+"/legend", wrapGetWithErrors(ef, s.arcgisLegend(id, db)))
+		m.Handle(p, wrapGetWithErrors(ef, hmacAuth(s.arcgisService(id, db), s.secretKey, id)))
+		m.Handle(p+"/layers", wrapGetWithErrors(ef, hmacAuth(s.arcgisLayers(id, db), s.secretKey, id)))
+		m.Handle(p+"/legend", wrapGetWithErrors(ef, hmacAuth(s.arcgisLegend(id, db), s.secretKey, id)))
 
-		m.Handle(p+"/tile/", wrapGetWithErrors(ef, s.arcgisTiles(db)))
+		m.Handle(p+"/tile/", wrapGetWithErrors(ef, hmacAuth(s.arcgisTiles(db), s.secretKey, id)))
 	}
 	return m
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -65,6 +65,10 @@ func wrapGetWithErrors(ef func(error), hf handlerFunc) http.Handler {
 	})
 }
 
+// hmacAuth wraps handler functions to provide request authentication. If
+// -s/--secret-key is provided at startup, this function will enforce proper
+// request signing. Otherwise, it will simply pass requests through to the
+// handler.
 func hmacAuth(hf handlerFunc, secretKey string, serviceId string) handlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) (int, error) {
 		// If secret key isn't set, allow all requests
@@ -90,7 +94,7 @@ func hmacAuth(hf handlerFunc, secretKey string, serviceId string) handlerFunc {
 			return 400, errors.New("No signature date provided")
 		}
 
-		signDate, err := time.Parse(time.RFC3339Nano, rawSignDate)
+		signDate, err := time.Parse(time.RFC3339Nano, date)
 		if err != nil {
 			return 400, errors.New("Signature date is not valid RFC3339")
 		}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 	privateKey  string
 	pathPrefix  string
 	domain      string
+	secretKey   string
 	sentryDSN   string
 	verbose     bool
 	autotls     bool
@@ -56,10 +57,15 @@ func init() {
 	flags.StringVarP(&privateKey, "key", "k", "", "TLS private key")
 	flags.StringVar(&pathPrefix, "path", "", "URL root path of this server (if behind a proxy)")
 	flags.StringVar(&domain, "domain", "", "Domain name of this server")
+	flags.StringVarP(&secretKey, "secret-key", "s", "", "Shared secret key used for HMAC authentication")
 	flags.StringVar(&sentryDSN, "dsn", "", "Sentry DSN")
 	flags.BoolVarP(&verbose, "verbose", "v", false, "Verbose logging")
 	flags.BoolVarP(&autotls, "tls", "t", false, "Auto TLS via Let's Encrypt")
 	flags.BoolVarP(&redirect, "redirect", "r", false, "Redirect HTTP to HTTPS")
+
+	if secretKey == "" {
+		secretKey = os.Getenv("MBTILESERVER_SECRET_KEY")
+	}
 }
 
 func main() {
@@ -132,7 +138,7 @@ func serve() {
 		log.Infof("Found %v mbtiles files in %s", len(filenames), tilePath)
 	}
 
-	svcSet, err := handlers.NewFromBaseDir(tilePath)
+	svcSet, err := handlers.NewFromBaseDir(tilePath, secretKey)
 	if err != nil {
 		log.Errorf("Unable to create service set: %v", err)
 	}


### PR DESCRIPTION
This PR adds optional support for authenticated requests based on a shared, secret key. Authenticated requests include an ISO-formatted date and a salted, base64-encoded HMAC signature hash. These authentication fields can be passed as query parameters or as request headers.

The hash payload is the ISO date (to prevent future replay of the request using a different date), and the service id (for per-service authentication).

Authentication is enabled by providing a secret key to `mbtileserver`, either by using the `-s` option:

```
mbtileserver -d tiles -p 8000 -s "secret-key-here"
```

... or using the `MBTILESERVER_SECRET_KEY` environment variable:

```
MBTILESERVER_SECRET_KEY=secret-key-here mbtileserver -d tiles -p 8000
```

Authentication is an opt-in feature. `mbtileserver` will continue to behave as usual, in full public mode if a secret key is not provided.