### PR TITLE
Fixes for graceful reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Flags:
   -s, --secret-key string Shared secret key used for HMAC authentication
   -t, --tls               Auto TLS using Let's Encrypt
   -r, --redirect          Redirect HTTP to HTTPS
-      --enable-reload     Enalbe graceful reload
+      --enable-reload     Enable graceful reload
   -v, --verbose           Verbose logging
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Flags:
   -s, --secret-key string Shared secret key used for HMAC authentication
   -t, --tls               Auto TLS using Let's Encrypt
   -r, --redirect          Redirect HTTP to HTTPS
+      --enable-reload     Enalbe graceful reload
   -v, --verbose           Verbose logging
 ```
 
@@ -121,8 +122,8 @@ mbtileserver:
 
 ### Reload
 
-mbtileserver supports graceful reload (without interrupting any in-progress requests). Reload the server by sending it a
-`HUP` signal:
+mbtileserver optionally supports graceful reload (without interrupting any in-progress requests). This functionality
+must be enabled with the `--enable-reload` flag. When enabled, the server can be reloaded by sending it a `HUP` signal:
 
 ```
 $ kill -HUP <pid>


### PR DESCRIPTION
This PR fixes two issues with the newly-introduced graceful reload functionality.

The first fix addresses #71 by making reload an optional feature, disabled by default. The functionality can be enabled by passing the `--enable-reload` flag at startup.

The second fix addresses a problem that would cause the primary process to exit when near-concurrent reload requests were received (the newly forked process would receive a `HUP` signal before the handler was registered, which resulted in the default handler being invoked and exiting the process; this in turn prompted the parent process to exit as well).

The fix for this adds a .5s wait between reloads, to give the new child process time to start and register its `HUP` handler.