### PR TITLE
Don’t try to load `.mbtiles` files during write

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -174,6 +174,10 @@ func NewFromBaseDir(baseDir string, secretKey string) (*ServiceSet, error) {
 		if err != nil {
 			return err
 		}
+		if _, err := os.Stat(p + "-journal"); err == nil {
+			// Don't try to load .mbtiles files that are being written
+			return nil
+		}
 		if ext := filepath.Ext(p); ext == ".mbtiles" {
 			filenames = append(filenames, p)
 		}

--- a/main.go
+++ b/main.go
@@ -196,6 +196,10 @@ func serve() {
 		if err != nil {
 			return err
 		}
+		if _, err := os.Stat(path + "-journal"); err == nil {
+			// Don't try to load .mbtiles files that are being written
+			return nil
+		}
 		if strings.HasSuffix(strings.ToLower(path), ".mbtiles") {
 			filenames = append(filenames, path)
 		}


### PR DESCRIPTION
I kept running into poorly timed reloads which would land during tile updates, causing `mbtileserver` to crash. It occurred to me that while scanning for tilesets, we could simply ignore those that have an accompanying `-journal` file, indicating it's being written.

So this PR does just that. Adds an additional condition to ignore journaled tilesets.