### PR TITLE
Fix tiles with mixed case not loading

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -197,7 +197,7 @@ func NewFromBaseDir(baseDir string, secretKey string) (*ServiceSet, error) {
 		}
 		e := filepath.Ext(filename)
 		p := filepath.ToSlash(subpath)
-		id := strings.ToLower(p[:len(p)-len(e)])
+		id := p[:len(p)-len(e)]
 		err = s.AddDBOnPath(filename, id)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
For example, tiles with following url could not be loaded before /services/EdWj4IH3T/tiles/{z}/{x}/{y}.pbf
This pull request fixes this. 