### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ server {
    <other config options>
 
     location /services {
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $server_name;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass http://localhost:8000;


### PR DESCRIPTION
`$host` variable is more appropriate here:
https://github.com/consbio/mbtileserver/blob/07d552cdcb60b3b882b3eb94d55e8b090ca4287d/README.md#L195-L204
Additional info: [[host_spoofing] Request's Host header forgery](https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md)