### PR TITLE
Fix handlers for ArcGIS

### DIFF
--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -218,8 +218,8 @@ func (s *ServiceSet) IDFromURLPath(id string) string {
 				id = id[:i]
 			}
 		}
-	} else if s.enableArcGIS && strings.HasPrefix(id, ArcGISRoot) {
-		id = strings.TrimPrefix(id, ArcGISRoot)
+	} else if s.enableArcGIS && strings.HasPrefix(id, ArcGISServicesRoot) {
+		id = strings.TrimPrefix(id, ArcGISServicesRoot)
 		// MapServer should be a reserved word, so should be OK to split on it
 		id = strings.Split(id, "/MapServer")[0]
 	} else {
@@ -253,7 +253,9 @@ func (s *ServiceSet) Handler() http.Handler {
 	}
 
 	if s.enableArcGIS {
-		m.HandleFunc(ArcGISRoot, s.tilesetHandler)
+		fmt.Println("ArcGIS root", ArcGISServicesRoot)
+		m.HandleFunc(ArcGISInfoRoot, s.arcgisInfoHandler)
+		m.HandleFunc(ArcGISServicesRoot, s.tilesetHandler)
 	} else {
 		m.Handle(ArcGISRoot, http.NotFoundHandler())
 	}

--- a/handlers/serviceset.go
+++ b/handlers/serviceset.go
@@ -253,7 +253,6 @@ func (s *ServiceSet) Handler() http.Handler {
 	}
 
 	if s.enableArcGIS {
-		fmt.Println("ArcGIS root", ArcGISServicesRoot)
 		m.HandleFunc(ArcGISInfoRoot, s.arcgisInfoHandler)
 		m.HandleFunc(ArcGISServicesRoot, s.tilesetHandler)
 	} else {

--- a/handlers/tile.go
+++ b/handlers/tile.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 )
 
-
 const (
 	earthRadius              = 6378137.0
 	earthCircumference       = math.Pi * earthRadius
@@ -63,7 +62,7 @@ func tileCoordFromString(z, x, y string) (tc tileCoord, ext string, err error) {
 	return
 }
 
-func calcScaleResolution(zoomLevel uint8, dpi uint8) (float64, float64) {
+func calcScaleResolution(zoomLevel int, dpi uint8) (float64, float64) {
 	var denom = 1 << zoomLevel
 	resolution := initialResolution / float64(denom)
 	scale := float64(dpi) * 39.37 * resolution // 39.37 in/m

--- a/handlers/tileset.go
+++ b/handlers/tileset.go
@@ -66,7 +66,7 @@ func newTileset(svc *ServiceSet, filename, id, path string) (*Tileset, error) {
 	}
 
 	if svc.enableArcGIS {
-		arcgisRoot := ArcGISRoot + id + "/MapServer"
+		arcgisRoot := ArcGISServicesRoot + id + "/MapServer"
 		m.HandleFunc(arcgisRoot, ts.arcgisServiceHandler)
 		m.HandleFunc(arcgisRoot+"/layers", ts.arcgisLayersHandler)
 		m.HandleFunc(arcgisRoot+"/legend", ts.arcgisLegendHandler)


### PR DESCRIPTION
This picks up the ArcGIS handler changes from #115, including fixes to LODs and tile origin point.

Temporarily (possibly long term) disables layer info at the service root and layers endpoint.

Adds an `info` endpoint normally provided by ArcGIS server.