### PR TITLE
Rename --root-url-path option and corresponding environment variable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can also use environment variables instead of flags, which may be more helpf
 -   `PORT` (`--port`)
 -   `TILE_DIR` (`--dir`)
 -   `GENERATE_IDS` (`--generate-ids`)
--   `ROOT_URL_PATH` (`--root-url-path`)
+-   `ROOT_URL` (`--root-url`)
 -   `DOMAIN` (`--domain`)
 -   `TLS_CERT` (`--cert`)
 -   `TLS_PRIVATE_KEY` (`--key`)


### PR DESCRIPTION
According to https://github.com/consbio/mbtileserver/pull/100 and the `CHANGELOG.md`, the `--path` option was renamed to `--root-url`, and the environment variable `ROOT_URL_PATH` was renamed to `ROOT_URL`.

The README should be updated in consequence. I am not sure that my proposition reflects the right values.