### PR TITLE
Include attribution in the preview map

### DIFF
--- a/handlers/templates/map_gl.html
+++ b/handlers/templates/map_gl.html
@@ -99,6 +99,7 @@
                         basemap: basemapSource,
                         overlay: {
                             type: "vector",
+                            attribution: tileJSON.attribution,
                             tiles: tileJSON.tiles,
                             minzoom: tileJSON.minzoom,
                             maxzoom: tileJSON.maxzoom


### PR DESCRIPTION
If the .mbtiles source contains an `attribution` string in the metadata table, then it will already be included in the generated TileJSON.

Add this to the `source` in the generated map preview as well.

![Screenshot 2021-10-22 14 30 44](https://user-images.githubusercontent.com/23022/138505727-65af24bb-9004-45df-acc9-152ac854b419.png)

