### PR TITLE
Update README.md with "go install" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ _Requires Go 1.16+._
 You can install this project with
 
 ```sh
-$  go get github.com/consbio/mbtileserver
+$  go install github.com/consbio/mbtileserver@latest
 ```
 
 This will create and install an executable called `mbtileserver`.


### PR DESCRIPTION
`go get github.com/consbio/mbtileserver` -> `go install github.com/consbio/mbtileserver@latest`

~~~
$ go get github.com/consbio/mbtileserver
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
~~~