### PR TITLE
ENH: Avoid protocol errors in log for handler

### DIFF
--- a/handlers/tileset.go
+++ b/handlers/tileset.go
@@ -260,7 +260,7 @@ func (ts *Tileset) tileHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, err = w.Write(data)
 
-	if err != nil && !errors.Is(err, syscall.EPIPE) {
+	if err != nil && !errors.Is(err, syscall.EPIPE) && !errors.Is(err, syscall.EPROTOTYPE) {
 		ts.svc.logError("Could not write tile data for %v: %v", r.URL.Path, err)
 
 	}


### PR DESCRIPTION
Occasionally the logs spit out errors related to socket errors, e.g., 

```
Could not write tile data for /services/<service>/tiles/7/36/50.pbf: write tcp [::1]:8001->[::1]:53424: write: protocol wrong type for socket
```

This should prevent that.