### PR TITLE
send correct proxy headers to support more scenarios like port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ server {
    <other config options>
 
     location /services {
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Ssl on;
         proxy_pass http://localhost:8000;

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ server {
 
     location /services {
         proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-Proto $scheme;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header X-Forwarded-Proto $scheme;
+	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Ssl on;
         proxy_pass http://localhost:8000;


### PR DESCRIPTION
Make the README example work in cases where:

Nginx container has a port mapping from host port 8080 to container port 80 (8080:80). Nginx listens on port 80 and clients connect to it using `localhost:8080`.

Make this scenario work using line `proxy_set_header Host $http_host`
