### PR TITLE
Update readme and docker compose to use ghcr.io/consbio/mbtileserver:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ To run the Docker container on port 8080 with your tilesets in `<host tile dir>`
 Note that by default, `mbtileserver` runs on port 8000 in the container.
 
 ```
-docker run --rm -p 8080:8000 -v <host tile dir>:/tilesets  consbio/mbtileserver
+docker run --rm -p 8080:8000 -v <host tile dir>:/tilesets  ghcr.io/consbio/mbtileserver:latest
 ```
 
 You can pass in additional command-line arguments to `mbtileserver`, for example, to use
@@ -268,7 +268,7 @@ certificates and files in `<host cert dir>` so that you can access the server vi
 [`mkcert`](https://github.com/FiloSottile/mkcert). This example uses automatic redirects, which causes `mbtileserver` to also listen on port 80 and automatically redirect to 443.
 
 ```
-docker run  --rm -p 80:80 -p 443:443 -v <host tile dir>:/tilesets -v <host cert dir>:/certs/ consbio/mbtileserver -c /certs/localhost.pem -k /certs/localhost-key.pem -p 443 --redirect
+docker run  --rm -p 80:80 -p 443:443 -v <host tile dir>:/tilesets -v <host cert dir>:/certs/ ghcr.io/consbio/mbtileserver:latest -c /certs/localhost.pem -k /certs/localhost-key.pem -p 443 --redirect
 ```
 
 Alternately, use `docker-compose` to run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     mbtileserver:
-        image: consbio/mbtileserver:latest
+        image: ghcr.io/consbio/mbtileserver:latest
         container_name: mbtileserver
         entrypoint: /mbtileserver --enable-reload-signal
         restart: always


### PR DESCRIPTION
I tried running the instructions but hit `mbtileserver Error manifest for consbio/mbtileserver:latest not found: manifest unknown: man..`. I've patched the readme and docker compose to use the working ghcr.io url